### PR TITLE
client: quote type annotation for options parameter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,14 @@ on:
       - master
 jobs:
   tests:
+    strategy:
+        matrix:
+          python-version: [ '3.7', '3.8', '3.9' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v2
       - uses: actions/checkout@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - run: pip install .
       - run: make test

--- a/src/pomerium/client.py
+++ b/src/pomerium/client.py
@@ -32,7 +32,7 @@ class AuthMetadataPlugin(grpc.AuthMetadataPlugin):
         callback((self._authorization_header,), None)
 
 
-def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: "list[tuple[str, str]]" = None):
+def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: 'list[tuple[str, str]]' = None):
     return grpc.secure_channel(target, grpc.composite_channel_credentials(
         grpc.ssl_channel_credentials(root_certificates=root_certificates,
                                      private_key=private_key, certificate_chain=certificate_chain),
@@ -46,7 +46,7 @@ class Client(object):
     """Client provides the top level interface to Pomerium API methods
     """
 
-    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: "list[tuple[str, str]]" = None):
+    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: 'list[tuple[str, str]]' = None):
         """Construct a new Client with a connection to the Pomerium API
         Args:
             target: "hostname:port" of pomerium console endpoint

--- a/src/pomerium/client.py
+++ b/src/pomerium/client.py
@@ -1,4 +1,5 @@
 import grpc
+from typing import List, Tuple
 from pomerium.pb.activity_log_pb2_grpc import ActivityLogServiceStub
 from pomerium.pb.key_chain_pb2_grpc import KeyChainServiceStub
 from pomerium.pb.namespaces_pb2_grpc import NamespacePermissionServiceStub
@@ -32,7 +33,7 @@ class AuthMetadataPlugin(grpc.AuthMetadataPlugin):
         callback((self._authorization_header,), None)
 
 
-def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: list[tuple[str, str]] = None):
+def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: List[Tuple[str, str]] = None):
     return grpc.secure_channel(target, grpc.composite_channel_credentials(
         grpc.ssl_channel_credentials(root_certificates=root_certificates,
                                      private_key=private_key, certificate_chain=certificate_chain),
@@ -46,7 +47,7 @@ class Client(object):
     """Client provides the top level interface to Pomerium API methods
     """
 
-    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: list[tuple[str, str]] = None):
+    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: List[Tuple[str, str]] = None):
         """Construct a new Client with a connection to the Pomerium API
         Args:
             target: "hostname:port" of pomerium console endpoint

--- a/src/pomerium/client.py
+++ b/src/pomerium/client.py
@@ -1,5 +1,4 @@
 import grpc
-from typing import List, Tuple
 from pomerium.pb.activity_log_pb2_grpc import ActivityLogServiceStub
 from pomerium.pb.key_chain_pb2_grpc import KeyChainServiceStub
 from pomerium.pb.namespaces_pb2_grpc import NamespacePermissionServiceStub
@@ -33,7 +32,7 @@ class AuthMetadataPlugin(grpc.AuthMetadataPlugin):
         callback((self._authorization_header,), None)
 
 
-def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: List[Tuple[str, str]] = None):
+def _dial(target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: "list[tuple[str, str]]" = None):
     return grpc.secure_channel(target, grpc.composite_channel_credentials(
         grpc.ssl_channel_credentials(root_certificates=root_certificates,
                                      private_key=private_key, certificate_chain=certificate_chain),
@@ -47,7 +46,7 @@ class Client(object):
     """Client provides the top level interface to Pomerium API methods
     """
 
-    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: List[Tuple[str, str]] = None):
+    def __init__(self, target: str, auth_token: str, root_certificates: bytes = None, private_key: bytes = None, certificate_chain: bytes = None, options: "list[tuple[str, str]]" = None):
         """Construct a new Client with a connection to the Pomerium API
         Args:
             target: "hostname:port" of pomerium console endpoint


### PR DESCRIPTION
This is to support older python versions that will fail on an annotation like `list[tuple[str,str]]`

Fixes https://github.com/pomerium/enterprise-client-python/issues/2