### PR TITLE
enterprise-client-python/ci: update github action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,9 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 50
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 50
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,13 +8,16 @@ on:
 jobs:
   tests:
     strategy:
-        matrix:
-          python-version: [ '3.7', '3.8', '3.9' ]
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+
+      - uses: actions/setup-python@9a7ac94420f42ee15fc60ab88d0dca4be1fd5757
         with:
           python-version: ${{ matrix.python-version }}
+
       - run: pip install .
+
       - run: make test


### PR DESCRIPTION
Update the github action to use pinned dependencies.